### PR TITLE
Feature/org accounts

### DIFF
--- a/Back-End/cloudformation/MainTemplate.yaml
+++ b/Back-End/cloudformation/MainTemplate.yaml
@@ -1,12 +1,12 @@
-AWSTemplateFormatVersion: '2010-09-09'
-Description: > 
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
   Template for primary account that will hold everything.
   aws cloudformation create-stack --stack-name MultiAccount --template-body file://MainTemplate.yaml --capabilities CAPABILITY_IAM
 
 Parameters:
   Accounts:
     Type: String
-    Default: '111111111111,222222222222,333333333333,444444444444,55555555555'
+    Default: "111111111111,222222222222,333333333333,444444444444,55555555555"
     Description: Account Numbers for all your sub accounts and admin account seperated by commas e.g '111111111111,2222222222222'
   LogRetention:
     Type: Number
@@ -18,15 +18,18 @@ Parameters:
     Description: Name of DynamoDB table
   SourceAccount:
     Type: Number
-    Default: '111111111111'
+    Default: "111111111111"
     Description: Administrator Account that is running this cloudformation template (Admin Account)
+  MasterAccount:
+    Type: String
+    Description: (Optional) Organization's Master Account. In most cases same as SourceAccount unless you're deploying MultiAccount Viewer into different account than Master one
   SourceRegion:
     Type: String
-    Default: 'ap-southeast-2'
+    Default: "us-east-1"
     Description: Region this template is running out of (Admin Account)
   Regions:
     Type: String
-    Default: 'ap-southeast-2,us-east-1'
+    Default: "us-east-1"
     Description: Regions you want watched, minimum us-east-1 for global resources like IAM.
   # US East (Ohio)	          us-east-2
   # US East (N. Virginia)	    us-east-1
@@ -77,9 +80,11 @@ Parameters:
     Type: Number
     Description: How high should DynamoDB scale
     Default: 250
+Conditions:
+  isMasterAccountDefined: !Not [!Equals [!Ref MasterAccount, ""]]
 
 Resources:
-# IAM Resources
+  # IAM Resources
   LambdaBackEndRole:
     Type: AWS::IAM::Role
     Properties:
@@ -90,12 +95,11 @@ Resources:
             Principal:
               Service: lambda.amazonaws.com
             Action: "sts:AssumeRole"
-      ManagedPolicyArns: 
+      ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
         - arn:aws:iam::aws:policy/ReadOnlyAccess
-      Tags: 
-        - 
-          Key: Name
+      Tags:
+        - Key: Name
           Value: !Sub "${AWS::StackName}-LambdaRole"
       Policies:
         - PolicyName: !Sub "${AWS::StackName}-LambdaDynamoDB"
@@ -128,16 +132,16 @@ Resources:
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
-            - Effect: Allow
-              Action:
-              - sqs:ReceiveMessage
-              - sqs:DeleteMessage
-              - sqs:SendMessage
-              - sqs:GetQueueAttributes
-              - sqs:ChangeMessageVisibility
-              Resource: 
-                - !GetAtt MyQueue.Arn
-                - !GetAtt ReceiverDeadLetterQueue.Arn
+              - Effect: Allow
+                Action:
+                  - sqs:ReceiveMessage
+                  - sqs:DeleteMessage
+                  - sqs:SendMessage
+                  - sqs:GetQueueAttributes
+                  - sqs:ChangeMessageVisibility
+                Resource:
+                  - !GetAtt MyQueue.Arn
+                  - !GetAtt ReceiverDeadLetterQueue.Arn
 
   # Scaling Role for DynamoDB
   ScalingRole:
@@ -146,26 +150,22 @@ Resources:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
-          -
-            Effect: "Allow"
+          - Effect: "Allow"
             Principal:
               Service:
                 - application-autoscaling.amazonaws.com
             Action:
               - "sts:AssumeRole"
       Path: "/"
-      Tags: 
-        - 
-          Key: Name
+      Tags:
+        - Key: Name
           Value: !Sub "${AWS::StackName}-AutoScalingRole"
       Policies:
-        -
-          PolicyName: "root"
+        - PolicyName: "root"
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
-              -
-                Effect: "Allow"
+              - Effect: "Allow"
                 Action:
                   - "dynamodb:DescribeTable"
                   - "dynamodb:UpdateTable"
@@ -176,7 +176,7 @@ Resources:
                   - "cloudwatch:DeleteAlarms"
                 Resource: "*"
 
-# SQS Queue
+  # SQS Queue
   MyQueue:
     Type: AWS::SQS::Queue
     Properties:
@@ -189,18 +189,16 @@ Resources:
             - ReceiverDeadLetterQueue
             - Arn
         maxReceiveCount: 1
-      Tags: 
-        - 
-          Key: Name
+      Tags:
+        - Key: Name
           Value: !Sub "${AWS::StackName}-MainSQS"
   # Dead Letter
   ReceiverDeadLetterQueue:
     Type: "AWS::SQS::Queue"
     Properties:
       MessageRetentionPeriod: 3600 # 1 hour.
-      Tags: 
-        - 
-          Key: Name
+      Tags:
+        - Key: Name
           Value: !Sub "${AWS::StackName}-DeadLetterSQS"
 
   LambdaFunctionEventSourceMapping:
@@ -211,7 +209,7 @@ Resources:
       EventSourceArn: !GetAtt MyQueue.Arn
       FunctionName: !GetAtt LambdaReceiveSQSFunction.Arn
 
-# Lambda Functions
+  # Lambda Functions
   LambdaSendSQSFunction:
     Type: AWS::Lambda::Function
     Properties:
@@ -228,16 +226,20 @@ Resources:
       Environment:
         Variables:
           ENV_SOURCE_ACCOUNT: !Ref SourceAccount
+          ENV_MASTER_ACCOUNT:
+            Fn::If:
+              - isMasterAccountDefined
+              - Ref: MasterAccount
+              - Ref: AWS::NoValue
           ENV_ACCOUNTS: !Ref Accounts
           ENV_SOURCE_REGION: !Ref SourceRegion
           ENV_REGIONS: !Ref Regions
           ENV_CROSS_ACCOUNT_ROLE: !Ref CrossAccountAccessRole
           ENV_SQSQUEUE: !Ref MyQueue
-      Tags: 
-        - 
-          Key: Name
+      Tags:
+        - Key: Name
           Value: !Sub "${AWS::StackName}-SendFunction"
-  
+
   LambdaReceiveSQSFunction:
     Type: AWS::Lambda::Function
     Properties:
@@ -258,9 +260,8 @@ Resources:
           ENV_CROSS_ACCOUNT_ROLE: !Ref CrossAccountAccessRole
           ENV_TABLE_NAME_MULTI: !Ref TableName
           ENV_SQSQUEUE: !Ref MyQueue
-      Tags: 
-        - 
-          Key: Name
+      Tags:
+        - Key: Name
           Value: !Sub "${AWS::StackName}-ReceiveFunction"
 
   LambdaListTableFunction:
@@ -280,153 +281,152 @@ Resources:
         Variables:
           ENV_SOURCE_REGION: !Ref SourceRegion
           ENV_TABLE_NAME_MULTI: !Ref TableName
-      Tags: 
-        - 
-          Key: Name
+      Tags:
+        - Key: Name
           Value: !Sub "${AWS::StackName}-ListTableFunction"
 
-# API Gateway Rest API
+  # API Gateway Rest API
   MyRestApi:
     Type: AWS::ApiGateway::RestApi
     Properties:
-        Name: !Sub ${AWS::StackName}-api
-        ApiKeySourceType: HEADER
-        Description: "Api for AWS Multi Account"
+      Name: !Sub ${AWS::StackName}-api
+      ApiKeySourceType: HEADER
+      Description: "Api for AWS Multi Account"
 
-# Api Gateway Resources
+  # Api Gateway Resources
   SearchResource:
-    Type: 'AWS::ApiGateway::Resource'
+    Type: "AWS::ApiGateway::Resource"
     Properties:
       ParentId: !GetAtt MyRestApi.RootResourceId
       RestApiId: !Ref MyRestApi
-      PathPart: 'search'
+      PathPart: "search"
 
   MessageResource:
-    Type: 'AWS::ApiGateway::Resource'
+    Type: "AWS::ApiGateway::Resource"
     Properties:
       ParentId: !GetAtt MyRestApi.RootResourceId
       RestApiId: !Ref MyRestApi
-      PathPart: 'message'
+      PathPart: "message"
 
-# Api Gateway Methods
+  # Api Gateway Methods
   APIListTable:
     Type: "AWS::ApiGateway::Method"
     Properties:
-        AuthorizationType: COGNITO_USER_POOLS
-        RestApiId: !Ref MyRestApi
-        ResourceId: !Ref SearchResource
-        AuthorizerId: !Ref Authorizer
-        HttpMethod: GET
-        Integration:
-            Type: AWS_PROXY
-            IntegrationHttpMethod: POST # DONT CHANGE THIS IT BREAKS EVERYTHING!!!!!
-            Uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${LambdaListTableFunction.Arn}/invocations"
-            IntegrationResponses:
-                - ResponseTemplates:
-                      application/json: ""
-                  StatusCode: "200"
-                  ResponseParameters:
-                      method.response.header.Access-Control-Allow-Origin : "'*'"
-        MethodResponses:
-          - ResponseModels: { "application/json": "Empty" }
-            StatusCode: 200
+      AuthorizationType: COGNITO_USER_POOLS
+      RestApiId: !Ref MyRestApi
+      ResourceId: !Ref SearchResource
+      AuthorizerId: !Ref Authorizer
+      HttpMethod: GET
+      Integration:
+        Type: AWS_PROXY
+        IntegrationHttpMethod: POST # DONT CHANGE THIS IT BREAKS EVERYTHING!!!!!
+        Uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${LambdaListTableFunction.Arn}/invocations"
+        IntegrationResponses:
+          - ResponseTemplates:
+              application/json: ""
+            StatusCode: "200"
             ResponseParameters:
-                method.response.header.Access-Control-Allow-Headers: true
-                method.response.header.Access-Control-Allow-Origin: true
-                method.response.header.Access-Control-Allow-Methods: true
+              method.response.header.Access-Control-Allow-Origin: "'*'"
+      MethodResponses:
+        - ResponseModels: { "application/json": "Empty" }
+          StatusCode: 200
+          ResponseParameters:
+            method.response.header.Access-Control-Allow-Headers: true
+            method.response.header.Access-Control-Allow-Origin: true
+            method.response.header.Access-Control-Allow-Methods: true
 
   APISendSQS:
     Type: "AWS::ApiGateway::Method"
     Properties:
-        AuthorizationType: COGNITO_USER_POOLS
-        RestApiId: !Ref MyRestApi
-        ResourceId: !Ref MessageResource
-        AuthorizerId: !Ref Authorizer
-        HttpMethod: GET
-        Integration:
-            Type: AWS_PROXY
-            IntegrationHttpMethod: POST # DONT CHANGE THIS IT BREAKS EVERYTHING!!!!!
-            Uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${LambdaSendSQSFunction.Arn}/invocations"
-            IntegrationResponses:
-                - ResponseTemplates:
-                      application/json: ""
-                  StatusCode: "200"
-                  ResponseParameters:
-                      method.response.header.Access-Control-Allow-Origin : "'*'"
-        MethodResponses:
-          - ResponseModels: { "application/json": "Empty" }
-            StatusCode: 200
+      AuthorizationType: COGNITO_USER_POOLS
+      RestApiId: !Ref MyRestApi
+      ResourceId: !Ref MessageResource
+      AuthorizerId: !Ref Authorizer
+      HttpMethod: GET
+      Integration:
+        Type: AWS_PROXY
+        IntegrationHttpMethod: POST # DONT CHANGE THIS IT BREAKS EVERYTHING!!!!!
+        Uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${LambdaSendSQSFunction.Arn}/invocations"
+        IntegrationResponses:
+          - ResponseTemplates:
+              application/json: ""
+            StatusCode: "200"
             ResponseParameters:
-                method.response.header.Access-Control-Allow-Headers: true
-                method.response.header.Access-Control-Allow-Origin: true
-                method.response.header.Access-Control-Allow-Methods: true
+              method.response.header.Access-Control-Allow-Origin: "'*'"
+      MethodResponses:
+        - ResponseModels: { "application/json": "Empty" }
+          StatusCode: 200
+          ResponseParameters:
+            method.response.header.Access-Control-Allow-Headers: true
+            method.response.header.Access-Control-Allow-Origin: true
+            method.response.header.Access-Control-Allow-Methods: true
 
   # Api Gateway Method for options
   APIListTableOptions:
     Type: "AWS::ApiGateway::Method"
     Properties:
-        AuthorizationType: NONE
-        RestApiId: !Ref MyRestApi
-        ResourceId: !Ref SearchResource
-        HttpMethod: OPTIONS
-        Integration:
-            Type: MOCK
-            IntegrationHttpMethod: OPTIONS
-            RequestTemplates:
-                application/json: "{\"statusCode\": 200}"
-            IntegrationResponses:
-              - ResponseTemplates:
-                    application/json: ""
-                StatusCode: "200"
-                ResponseParameters:
-                    method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
-                    method.response.header.Access-Control-Allow-Methods : "'POST,OPTIONS,GET'"
-                    method.response.header.Access-Control-Allow-Origin : "'*'"
-        MethodResponses:
-          - ResponseModels: { "application/json": "Empty" }
-            StatusCode: 200
+      AuthorizationType: NONE
+      RestApiId: !Ref MyRestApi
+      ResourceId: !Ref SearchResource
+      HttpMethod: OPTIONS
+      Integration:
+        Type: MOCK
+        IntegrationHttpMethod: OPTIONS
+        RequestTemplates:
+          application/json: '{"statusCode": 200}'
+        IntegrationResponses:
+          - ResponseTemplates:
+              application/json: ""
+            StatusCode: "200"
             ResponseParameters:
-                method.response.header.Access-Control-Allow-Headers: true
-                method.response.header.Access-Control-Allow-Methods: true
-                method.response.header.Access-Control-Allow-Origin: true
+              method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
+              method.response.header.Access-Control-Allow-Methods: "'POST,OPTIONS,GET'"
+              method.response.header.Access-Control-Allow-Origin: "'*'"
+      MethodResponses:
+        - ResponseModels: { "application/json": "Empty" }
+          StatusCode: 200
+          ResponseParameters:
+            method.response.header.Access-Control-Allow-Headers: true
+            method.response.header.Access-Control-Allow-Methods: true
+            method.response.header.Access-Control-Allow-Origin: true
 
   APISendSQSOptions:
     Type: "AWS::ApiGateway::Method"
     Properties:
-        AuthorizationType: NONE
-        RestApiId: !Ref MyRestApi
-        ResourceId: !Ref MessageResource
-        HttpMethod: OPTIONS
-        Integration:
-            Type: MOCK
-            IntegrationHttpMethod: OPTIONS
-            RequestTemplates:
-                application/json: "{\"statusCode\": 200}"
-            IntegrationResponses:
-              - ResponseTemplates:
-                    application/json: ""
-                StatusCode: "200"
-                ResponseParameters:
-                    method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
-                    method.response.header.Access-Control-Allow-Methods : "'POST,OPTIONS,GET'"
-                    method.response.header.Access-Control-Allow-Origin : "'*'"
-        MethodResponses:
-          - ResponseModels: { "application/json": "Empty" }
-            StatusCode: 200
+      AuthorizationType: NONE
+      RestApiId: !Ref MyRestApi
+      ResourceId: !Ref MessageResource
+      HttpMethod: OPTIONS
+      Integration:
+        Type: MOCK
+        IntegrationHttpMethod: OPTIONS
+        RequestTemplates:
+          application/json: '{"statusCode": 200}'
+        IntegrationResponses:
+          - ResponseTemplates:
+              application/json: ""
+            StatusCode: "200"
             ResponseParameters:
-                method.response.header.Access-Control-Allow-Headers: true
-                method.response.header.Access-Control-Allow-Methods: true
-                method.response.header.Access-Control-Allow-Origin: true
+              method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
+              method.response.header.Access-Control-Allow-Methods: "'POST,OPTIONS,GET'"
+              method.response.header.Access-Control-Allow-Origin: "'*'"
+      MethodResponses:
+        - ResponseModels: { "application/json": "Empty" }
+          StatusCode: 200
+          ResponseParameters:
+            method.response.header.Access-Control-Allow-Headers: true
+            method.response.header.Access-Control-Allow-Methods: true
+            method.response.header.Access-Control-Allow-Origin: true
 
-# Cognito User pool
+  # Cognito User pool
   CognitoUserPool:
     Type: AWS::Cognito::UserPool
     Properties:
       UserPoolName: !Sub ${AWS::StackName}_UserPool
       AliasAttributes:
-        - 'email'
+        - "email"
       AutoVerifiedAttributes:
-        - 'email'
+        - "email"
       AdminCreateUserConfig:
         AllowAdminCreateUserOnly: True
       Policies:
@@ -437,25 +437,25 @@ Resources:
           RequireSymbols: False
           RequireUppercase: True
 
-# Cognito Client
+  # Cognito Client
   CognitoUserPoolClient:
     Type: AWS::Cognito::UserPoolClient
     Properties:
       ClientName: !Sub ${AWS::StackName}_UserPoolClient
       UserPoolId: !Ref CognitoUserPool
 
-# API GateWay Authorizer
-  Authorizer: 
+  # API GateWay Authorizer
+  Authorizer:
     Type: AWS::ApiGateway::Authorizer
-    Properties:                  
+    Properties:
       Type: "COGNITO_USER_POOLS"
       IdentitySource: "method.request.header.Authorization"
       Name: !Sub ${AWS::StackName}CognitoAuthorizer
       RestApiId: !Ref MyRestApi
-      ProviderARNs: 
-        - !GetAtt "CognitoUserPool.Arn"   
+      ProviderARNs:
+        - !GetAtt "CognitoUserPool.Arn"
 
-# API Gateway Deployment
+  # API Gateway Deployment
   ApiGatewayDeployment:
     Type: AWS::ApiGateway::Deployment
     Properties:
@@ -467,31 +467,31 @@ Resources:
       - APISendSQS
       - APIListTable
 
-# Cron Rule to refresh dynamodb table
-  ScheduledRule: 
+  # Cron Rule to refresh dynamodb table
+  ScheduledRule:
     Type: AWS::Events::Rule
-    Properties: 
+    Properties:
       Description: "ScheduledRule"
       ScheduleExpression: !Ref CronTimer
       State: "ENABLED"
-      Targets: 
+      Targets:
         - Arn: !GetAtt
-              - "LambdaSendSQSFunction"
-              - "Arn"
+            - "LambdaSendSQSFunction"
+            - "Arn"
           Id: "TargetFunctionV1"
           Input: '{"queryStringParameters":{"function": "cron"}}'
 
-# Lambda Permission for Cron
-  PermissionForEventsToInvokeLambda: 
+  # Lambda Permission for Cron
+  PermissionForEventsToInvokeLambda:
     Type: AWS::Lambda::Permission
-    Properties: 
+    Properties:
       Action: "lambda:InvokeFunction"
       FunctionName: !GetAtt "LambdaSendSQSFunction.Arn"
       Principal: "events.amazonaws.com"
       SourceArn: !GetAtt "ScheduledRule.Arn"
 
-# Lambda Permissions API Gateway
-  LambdaApiListTableGatewayInvoke: 
+  # Lambda Permissions API Gateway
+  LambdaApiListTableGatewayInvoke:
     Type: "AWS::Lambda::Permission"
     Properties:
       Action: "lambda:InvokeFunction"
@@ -499,8 +499,8 @@ Resources:
       Principal: "apigateway.amazonaws.com"
       SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${MyRestApi}/*/*"
 
-# Lambda Permissions API Gateway
-  LambdaApiSendSQSGatewayInvoke: 
+  # Lambda Permissions API Gateway
+  LambdaApiSendSQSGatewayInvoke:
     Type: "AWS::Lambda::Permission"
     Properties:
       Action: "lambda:InvokeFunction"
@@ -508,152 +508,149 @@ Resources:
       Principal: "apigateway.amazonaws.com"
       SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${MyRestApi}/*/*"
 
-
-# Logs Retention for Lambdas
+  # Logs Retention for Lambdas
   LogGroupSendFunction:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Join ['/', ['/aws/lambda', !Ref LambdaSendSQSFunction]]
+      LogGroupName: !Join ["/", ["/aws/lambda", !Ref LambdaSendSQSFunction]]
       RetentionInDays: !Ref LogRetention
 
   LogGroupReceiveFunction:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Join ['/', ['/aws/lambda', !Ref LambdaReceiveSQSFunction]]
+      LogGroupName: !Join ["/", ["/aws/lambda", !Ref LambdaReceiveSQSFunction]]
       RetentionInDays: !Ref LogRetention
 
   LogGroupListFunction:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Join ['/', ['/aws/lambda', !Ref LambdaListTableFunction]]
-      RetentionInDays: !Ref LogRetention 
+      LogGroupName: !Join ["/", ["/aws/lambda", !Ref LambdaListTableFunction]]
+      RetentionInDays: !Ref LogRetention
 
-# DynamoDB Table
+  # DynamoDB Table
   DynamoMultiAccountTable:
-     Type: AWS::DynamoDB::Table
-     Properties: 
-       SSESpecification:
-          SSEEnabled: True
-       TableName: !Ref TableName
-       AttributeDefinitions: 
-         - AttributeName: Id
-           AttributeType: S
-         - AttributeName: EntryType
-           AttributeType: S
-       KeySchema: 
-         - AttributeName: Id
-           KeyType: HASH
-       ProvisionedThroughput: 
-         ReadCapacityUnits: 25
-         WriteCapacityUnits: 25
-       GlobalSecondaryIndexes:
-         -
-          IndexName: "EntryType-index"
+    Type: AWS::DynamoDB::Table
+    Properties:
+      SSESpecification:
+        SSEEnabled: True
+      TableName: !Ref TableName
+      AttributeDefinitions:
+        - AttributeName: Id
+          AttributeType: S
+        - AttributeName: EntryType
+          AttributeType: S
+      KeySchema:
+        - AttributeName: Id
+          KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: 25
+        WriteCapacityUnits: 25
+      GlobalSecondaryIndexes:
+        - IndexName: "EntryType-index"
           KeySchema:
             - AttributeName: EntryType
               KeyType: HASH
-          Projection: 
+          Projection:
             ProjectionType: ALL
           ProvisionedThroughput:
             ReadCapacityUnits: 25
             WriteCapacityUnits: 25
-       Tags:
-         - 
-           Key: Name
-           Value: !Sub "${AWS::StackName}-DynamoDBTable"
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-DynamoDBTable"
 
   # DynamoDB Scaling
-  UserTableWriteCapacityScalableTarget: 
+  UserTableWriteCapacityScalableTarget:
     Type: "AWS::ApplicationAutoScaling::ScalableTarget"
-    Properties: 
+    Properties:
       MaxCapacity: !Ref MaxDynamoScaleSpeed
       MinCapacity: !Ref MinDynamoScaleSpeed
       ResourceId: !Sub table/${TableName}
       RoleARN: !GetAtt ScalingRole.Arn
       ScalableDimension: "dynamodb:table:WriteCapacityUnits"
       ServiceNamespace: dynamodb
-  UserTableWriteScalingPolicy: 
+  UserTableWriteScalingPolicy:
     Type: "AWS::ApplicationAutoScaling::ScalingPolicy"
-    Properties: 
+    Properties:
       PolicyName: WriteAutoScalingPolicy
       PolicyType: TargetTrackingScaling
-      ScalingTargetId: 
+      ScalingTargetId:
         Ref: UserTableWriteCapacityScalableTarget
-      TargetTrackingScalingPolicyConfiguration: 
+      TargetTrackingScalingPolicyConfiguration:
         TargetValue: 70
         ScaleInCooldown: 60
         ScaleOutCooldown: 60
-        PredefinedMetricSpecification: 
+        PredefinedMetricSpecification:
           PredefinedMetricType: DynamoDBWriteCapacityUtilization
-  UserIndexWriteCapacityScalableTarget: 
+  UserIndexWriteCapacityScalableTarget:
     Type: "AWS::ApplicationAutoScaling::ScalableTarget"
-    Properties: 
+    Properties:
       MaxCapacity: !Ref MaxDynamoScaleSpeed
       MinCapacity: !Ref MinDynamoScaleSpeed
       ResourceId: !Sub table/${TableName}/index/EntryType-index
       RoleARN: !GetAtt ScalingRole.Arn
       ScalableDimension: "dynamodb:index:WriteCapacityUnits"
       ServiceNamespace: dynamodb
-  UserIndexWriteScalingPolicy: 
+  UserIndexWriteScalingPolicy:
     Type: "AWS::ApplicationAutoScaling::ScalingPolicy"
-    Properties: 
+    Properties:
       PolicyName: WriteAutoScalingPolicy
       PolicyType: TargetTrackingScaling
-      ScalingTargetId: 
+      ScalingTargetId:
         Ref: UserIndexWriteCapacityScalableTarget
-      TargetTrackingScalingPolicyConfiguration: 
+      TargetTrackingScalingPolicyConfiguration:
         TargetValue: 70
         ScaleInCooldown: 60
         ScaleOutCooldown: 60
-        PredefinedMetricSpecification: 
+        PredefinedMetricSpecification:
           PredefinedMetricType: DynamoDBWriteCapacityUtilization
-  UserTableReadCapacityScalableTarget: 
+  UserTableReadCapacityScalableTarget:
     Type: "AWS::ApplicationAutoScaling::ScalableTarget"
-    Properties: 
+    Properties:
       MaxCapacity: !Ref MaxDynamoScaleSpeed
       MinCapacity: !Ref MinDynamoScaleSpeed
       ResourceId: !Sub table/${TableName}
       RoleARN: !GetAtt ScalingRole.Arn
       ScalableDimension: "dynamodb:table:ReadCapacityUnits"
       ServiceNamespace: dynamodb
-  UserTableReadScalingPolicy: 
+  UserTableReadScalingPolicy:
     Type: "AWS::ApplicationAutoScaling::ScalingPolicy"
-    Properties: 
+    Properties:
       PolicyName: ReadAutoScalingPolicy
       PolicyType: TargetTrackingScaling
-      ScalingTargetId: 
+      ScalingTargetId:
         Ref: UserTableReadCapacityScalableTarget
-      TargetTrackingScalingPolicyConfiguration: 
+      TargetTrackingScalingPolicyConfiguration:
         TargetValue: 70
         ScaleInCooldown: 60
         ScaleOutCooldown: 60
-        PredefinedMetricSpecification: 
+        PredefinedMetricSpecification:
           PredefinedMetricType: DynamoDBReadCapacityUtilization
-  UserIndexReadCapacityScalableTarget: 
+  UserIndexReadCapacityScalableTarget:
     Type: "AWS::ApplicationAutoScaling::ScalableTarget"
-    Properties: 
+    Properties:
       MaxCapacity: !Ref MaxDynamoScaleSpeed
       MinCapacity: !Ref MinDynamoScaleSpeed
       ResourceId: !Sub table/${TableName}/index/EntryType-index
       RoleARN: !GetAtt ScalingRole.Arn
       ScalableDimension: "dynamodb:index:ReadCapacityUnits"
       ServiceNamespace: dynamodb
-  UserIndexReadScalingPolicy: 
+  UserIndexReadScalingPolicy:
     Type: "AWS::ApplicationAutoScaling::ScalingPolicy"
-    Properties: 
+    Properties:
       PolicyName: ReadAutoScalingPolicy
       PolicyType: TargetTrackingScaling
-      ScalingTargetId: 
+      ScalingTargetId:
         Ref: UserIndexReadCapacityScalableTarget
-      TargetTrackingScalingPolicyConfiguration: 
+      TargetTrackingScalingPolicyConfiguration:
         TargetValue: 70
         ScaleInCooldown: 60
         ScaleOutCooldown: 60
-        PredefinedMetricSpecification: 
+        PredefinedMetricSpecification:
           PredefinedMetricType: DynamoDBReadCapacityUtilization
 
 Outputs:
-  UserPoolId: 
+  UserPoolId:
     Value: !Ref CognitoUserPool
     Export:
       Name: !Sub ${AWS::StackName}-CognitoUserPool

--- a/Back-End/lambdas/send_sqs_message.py
+++ b/Back-End/lambdas/send_sqs_message.py
@@ -78,7 +78,21 @@ def send_sqs_message(accountNumber, function, region):
     return response
 
 
+def org_account_id():
+    """
+    Identify Org's Master Account
+
+    In case AccountViewer has been deployed into a different account than the master one then we need this function
+    to properly deal with listing account in our org.
+    """
+    if 'ENV_MASTER_ACCOUNT' in os.environ:
+        return os.environ['ENV_MASTER_ACCOUNT']
+    else:
+        return source_account
+
 # Lambda Handler
+
+
 def lambda_handler(event, context):
 
     try:
@@ -132,9 +146,7 @@ def lambda_handler(event, context):
 
             # if cron, send all messages to all accounts
             if passed_function == 'cron':
-
-                # Organizations only needs source_account
-                send_sqs_message(accountNumber=source_account,
+                send_sqs_message(accountNumber=org_account_id(),
                                  function='org', region='us-east-1')
 
                 for i in list_of_accounts:
@@ -180,7 +192,7 @@ def lambda_handler(event, context):
 
             # if function is organizations
             elif passed_function == 'org':
-                send_sqs_message(accountNumber=source_account,
+                send_sqs_message(accountNumber=org_account_id(),
                                  function='org', region='us-east-1')
 
             # if function is global and doesn't need each region


### PR DESCRIPTION
- Updates template to include "MasterAccount" parameter. If defined then define `ENV_MASTER_ACCOUNT` variable in send_sqs_message lambda function.
- Updated send_sqs_message.py  function to respect `ENV_MASTER_ACCOUNT` variable. If AccountViewer is deployed into org's master account then it's not needed. However if deployed into different account (monitoring etc) then queries related to org will be passed to the account defined in `ENV_MASTER_ACCOUNT` (if provided).

Summary:
It can be deployed to master/non-master account. `ENV_MASTER_ACCOUNT` is only needed in the second case.